### PR TITLE
Enable loopback device at the UP context for netns nodes

### DIFF
--- a/bin/tn
+++ b/bin/tn
@@ -218,6 +218,7 @@ def command_up(args):
           node['image']))
       elif nodetype == 'netns':
         print('ip netns add {}{}'.format(appinfo.namespace, node['name']))
+        print('ip netns exec {}{} ip link set lo up'.format(appinfo.namespace, node['name']))
       else:
         print('unknown node-type {}'.format(node['type']))
         sys.exit(1)


### PR DESCRIPTION
For netns targets, it is better to enable the loopback device on UP for consistency between Docker container targets.