### PR TITLE
Add new attribute to set base network for docker node type

### DIFF
--- a/bin/tn
+++ b/bin/tn
@@ -211,12 +211,18 @@ def command_up(args):
   if 'nodes' in appinfo.data:
     for node in appinfo.data['nodes']:
       nodetype = node.get('type', 'docker')
+      net_base = node.get('net_base', None)
       if nodetype == 'docker':
-        print('docker run -td --hostname {} --net=none '
+        if net_base == None:
+          net_base = 'none'
+        print('docker run -td --hostname {} --net {} '
           '--name {}{} --rm --privileged {}'
-          .format(node['name'], appinfo.namespace, node['name'],
+          .format(node['name'], net_base, appinfo.namespace, node['name'],
           node['image']))
       elif nodetype == 'netns':
+        if net_base != None:
+          print('You cannot use net_base with type: netns')
+          sys.exit(1)
         print('ip netns add {}{}'.format(appinfo.namespace, node['name']))
         print('ip netns exec {}{} ip link set lo up'.format(appinfo.namespace, node['name']))
       else:


### PR DESCRIPTION
The current tinet automatically uses `--net none` for Docker nodes. But, sometimes it is useful to use other networks like `bridge` or `host`. This patch introduces a new spec attribute `net_base` which can be specified for each node. Users can specify any of the networks that appears to the `docker network ls`.

The change won't break the existing manifests. It still uses `none` if no `net_base` was specified. It also generates error message if users specify the `net_base` for netns node type. 

Example spec

```
nodes:
  - name: client
    type: netns
    interfaces:
      - { name: net0, type: direct, args: server#net0 }

  - name: server
    image: nginx:latest
    net_base: bridge
    interfaces:
      - { name: net0, type: direct, args: client#net0 }
<...>
```